### PR TITLE
Avoid failure if the MySQL daemon startup is slow

### DIFF
--- a/init_jeedom_db.sh
+++ b/init_jeedom_db.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 /usr/bin/mysqld_safe &
-sleep 5
+mysqladmin --silent --wait=30 ping || exit 1
 mysql -u root -p${MYSQL_ROOT_PASSWORD} < /tmp/create_jeedom_db.sql


### PR DESCRIPTION
Wait 30s or until the MySQL daemon is ready. Exit properly on timeout.